### PR TITLE
Performance: Use a local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ or just run
 
 `:lua require("sigma_picker.installer").install_sigma_target()`
 
+Since version 1.1.1, sigma_picker creates a local cache the first time you try to
+install a sigma plugin. This helps speed up subsequent plugin installations. In
+case you want to clear the cache, run
+
+`lua require("sigma_picker.installer").refresh_cache()`
+
+> It doesn't actually refresh, it just removes the cache. You have to run the installer
+> again to get a new cache. All performance penalties will apply, just like installing the first time.
+
 > ~~I'm using sigmac. I know it's deprecated. Thanks for reminding me~~. Successfully moved to sigma-cli
 
 > I also wrote a silly little lsp to help me when writing sigma rules. You can get it [here](https://github.com/pop-ecx/sigma-ls.git). Works pretty well with the picker

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ or just run
 
 `:lua require("sigma_picker.installer").install_sigma_target()`
 
-Since version 1.1.1, sigma_picker creates a local cache the first time you try to
+Since version 1.2.1, sigma_picker creates a local cache the first time you try to
 install a sigma plugin. This helps speed up subsequent plugin installations. In
 case you want to clear the cache, run
 

--- a/lua/sigma_picker/installer.lua
+++ b/lua/sigma_picker/installer.lua
@@ -112,4 +112,13 @@ M.install_sigma_target = function(opts)
     }):find()
 end
 
+M.refresh_cache = function()
+  local success, err = os.remove(cache_path)
+  if success then
+    vim.notify("✅ Sigma plugin cache cleared successfully", vim.log.levels.INFO)
+  else
+    vim.notify("ℹ️ Failed to clear sigma plugin cache: ", err, vim.log.levels.WARN)
+  end
+end
+
 return M

--- a/lua/sigma_picker/installer.lua
+++ b/lua/sigma_picker/installer.lua
@@ -3,29 +3,45 @@ local finders = require("telescope.finders")
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 local conf = require("telescope.config").values
+local cache_path = vim.fn.stdpath("data") .. "/sigma_cache.json"
 
 local M = {}
 
 M.install_sigma_target = function(opts)
     opts = opts or {}
-
-    local result = vim.fn.system("sigma plugin list")
-    if vim.v.shell_error ~= 0 then
-        vim.notify("Failed to list Sigma plugins:\n" .. result, vim.log.levels.ERROR)
-        return
-    end
-
     local available_targets = {}
-    for line in result:gmatch("[^\r\n]+") do
-        if not line:match("^%+") and not line:match("|%s*Identifier%s*|") and line:match("%S") then
-            local target = line:match("^|%s*([^|]+)%s*|")
-            if target then
-                target = target:gsub("^%s+", ""):gsub("%s+$", "")
-                if target ~= "" then
-                    table.insert(available_targets, target)
-                end
-            end
-        end
+
+    local cache_exists = io.open(cache_path, "r")
+    if cache_exists then
+        local data = cache_exists:read("*a")
+        cache_exists:close()
+        available_targets = vim.fn.json_decode(data)
+    else
+      vim.notify("First-time setup: Fetching available sigma targets. This may take a moment...", vim.log.levels.INFO)
+      vim.cmd("redraw")
+
+      local result = vim.fn.system("sigma plugin list")
+      if vim.v.shell_error ~= 0 then
+          vim.notify("Failed to list Sigma plugins:\n" .. result, vim.log.levels.ERROR)
+          return
+      end
+
+      for line in result:gmatch("[^\r\n]+") do
+          if not line:match("^%+") and not line:match("|%s*Identifier%s*|") and line:match("%S") then
+              local target = line:match("^|%s*([^|]+)%s*|")
+              if target then
+                  target = target:gsub("^%s+", ""):gsub("%s+$", "")
+                  if target ~= "" then
+                      table.insert(available_targets, target)
+                  end
+              end
+          end
+      end
+      local file = io.open(cache_path, "w")
+      if file then
+          file:write(vim.fn.json_encode(available_targets))
+          file:close()
+      end
     end
 
     if #available_targets == 0 then


### PR DESCRIPTION
Running the installer every time you wish to install a plugin takes a long time, as much as 2 mins. This PR aims to fix that by creating a local cache the first time a plugin installation list is invoked. The cache is then used for subsequent installation activities. The performance penalty is only incurred the first time plugin list is invoked.