### PR TITLE
Uninstall sigma plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Since version 1.2.1, sigma_picker creates a local cache the first time you try t
 install a sigma plugin. This helps speed up subsequent plugin installations. In
 case you want to clear the cache, run
 
-`lua require("sigma_picker.installer").refresh_cache()`
+`:lua require("sigma_picker.installer").refresh_cache()`
 
 > It doesn't actually refresh, it just removes the cache. You have to run the installer
 > again to get a new cache. All performance penalties will apply, just like installing the first time.
@@ -81,9 +81,17 @@ Check installed targets or pipelines??
 
 run:
 
-`lua require("sigma_picker.targets").list_targets()` or
+`:lua require("sigma_picker.targets").list_targets()` or
 
-`lua require("sigma_picker.targets").list_pipelines()`
+`:lua require("sigma_picker.targets").list_pipelines()`
+
+Since version 1.2.2, you can also uninstall plugins. The local cache now has a
+way to track installed plugins. To uninstall a plugin, run
+
+`:lua require("sigma_picker.installer").uninstall_sigma_target()`
+
+This will bring up a picker with all installed plugins. Choose the one you want
+to uninstall and it will be removed from your system. The cache will update accordingly.
 
 > ~~I'm using sigmac. I know it's deprecated. Thanks for reminding me~~. Successfully moved to sigma-cli
 

--- a/lua/sigma_picker/installer.lua
+++ b/lua/sigma_picker/installer.lua
@@ -8,41 +8,65 @@ local entry_display = require("telescope.pickers.entry_display")
 
 local M = {}
 
+local function read_cache()
+    local file = io.open(cache_path, "r")
+    if not file then return nil end
+    local data = file:read("*a")
+    file:close()
+    local ok, decoded = pcall(vim.fn.json_decode, data)
+    return ok and decoded or nil
+end
+
+local function write_cache(cache)
+    local file = io.open(cache_path, "w")
+    if file then
+        file:write(vim.fn.json_encode(cache))
+        file:close()
+    end
+end
+
+local function update_installed(id, state)
+    local cache = read_cache()
+    if not cache then return end
+    for _, entry in ipairs(cache) do
+        if entry.id == id then
+            entry.installed = state
+            break
+        end
+    end
+    write_cache(cache)
+end
+
 M.install_sigma_target = function(opts)
     opts = opts or {}
     local available_targets = {}
 
-    local cache_exists = io.open(cache_path, "r")
-    if cache_exists then
-        local data = cache_exists:read("*a")
-        cache_exists:close()
-        available_targets = vim.fn.json_decode(data)
+    local cache = read_cache()
+    if cache then
+        available_targets = cache
     else
-      vim.notify("First-time setup: Fetching available sigma targets. This may take a moment...", vim.log.levels.INFO)
-      vim.cmd("redraw")
+        vim.notify("First-time setup: Fetching available sigma targets. This may take a moment...", vim.log.levels.INFO)
+        vim.cmd("redraw")
 
-      local result = vim.fn.system("sigma plugin list")
-      if vim.v.shell_error ~= 0 then
-          vim.notify("Failed to list Sigma plugins:\n" .. result, vim.log.levels.ERROR)
-          return
-      end
+        local result = vim.fn.system("sigma plugin list")
+        if vim.v.shell_error ~= 0 then
+            vim.notify("Failed to list Sigma plugins:\n" .. result, vim.log.levels.ERROR)
+            return
+        end
 
-      for line in result:gmatch("[^\r\n]+") do
-          if line:match("^|") and not line:match("Identifier") then
-              local id, _, _, _, compat = line:match("^|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|")
-              if id and id:match("%S") then
-                  table.insert(available_targets, {
-                      id = id:gsub("%s+", ""),
-                      compatible = compat:gsub("%s+", ""):lower() == "yes"
-                  })
-              end
-          end
-      end
-      local file = io.open(cache_path, "w")
-      if file then
-          file:write(vim.fn.json_encode(available_targets))
-          file:close()
-      end
+        for line in result:gmatch("[^\r\n]+") do
+            if line:match("^|") and not line:match("Identifier") then
+                local id, _, _, _, compat = line:match("^|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|%s*([^|]+)%s*|")
+                if id and id:match("%S") then
+                    table.insert(available_targets, {
+                        id = id:gsub("%s+", ""),
+                        compatible = compat:gsub("%s+", ""):lower() == "yes",
+                        installed = false,
+                    })
+                end
+            end
+        end
+        write_cache(available_targets)
     end
 
     if #available_targets == 0 then
@@ -117,10 +141,12 @@ M.install_sigma_target = function(opts)
 
                         if output:match("Successfully installed plugin") then
                             vim.schedule(function()
+                                update_installed(chosen, true)
                                 vim.notify("✅ Installed: " .. chosen, vim.log.levels.INFO)
                             end)
                         elseif output:match("already installed") or error_output:match("already installed") then
                             vim.schedule(function()
+                                update_installed(chosen, true)
                                 vim.notify("ℹ️ Already installed: " .. chosen, vim.log.levels.INFO)
                             end)
                         elseif code == 0 then
@@ -140,13 +166,121 @@ M.install_sigma_target = function(opts)
     }):find()
 end
 
+-- Sigma doesn't provide a way to list installed plugins only afaik,
+-- so we rely on our cache to determine which plugins are installed.
+M.uninstall_sigma_target = function(opts)
+    opts = opts or {}
+
+    local cache = read_cache()
+    if not cache then
+        vim.notify("No plugin cache found. Try installing a plugin first.", vim.log.levels.WARN)
+        return
+    end
+
+    local installed_plugins = {}
+    for _, entry in ipairs(cache) do
+        if entry.installed == true then
+            table.insert(installed_plugins, entry.id)
+        end
+    end
+
+    if #installed_plugins == 0 then
+        vim.notify("No installed Sigma plugins found to uninstall.", vim.log.levels.WARN)
+        return
+    end
+
+    local displayer = entry_display.create {
+        separator = " ",
+        items = {
+            { width = 25 },
+            { remaining = true },
+        },
+    }
+
+    local make_display = function(entry)
+        return displayer {
+            { entry.id, "TelescopeResultsIdentifier" },
+            { "(installed)", "Comment" },
+        }
+    end
+
+    pickers.new(opts, {
+        prompt_title = "Uninstall Sigma Plugin",
+        finder = finders.new_table {
+            results = installed_plugins,
+            entry_maker = function(entry)
+                return {
+                    value = entry,
+                    display = make_display,
+                    ordinal = entry,
+                    id = entry,
+                }
+            end,
+        },
+        sorter = conf.generic_sorter(opts),
+        attach_mappings = function(prompt_bufnr, _)
+            actions.select_default:replace(function()
+                local selection = action_state.get_selected_entry()
+                actions.close(prompt_bufnr)
+
+                local chosen = selection.value
+                local cmd = "sigma plugin uninstall " .. chosen
+                local stdout, stderr = {}, {}
+
+                vim.fn.jobstart(cmd, {
+                    stdout_buffered = true,
+                    stderr_buffered = true,
+                    on_stdout = function(_, data)
+                        if data then
+                            for _, line in ipairs(data) do
+                                if line ~= "" then
+                                    table.insert(stdout, line)
+                                end
+                            end
+                        end
+                    end,
+                    on_stderr = function(_, data)
+                        if data then
+                            for _, line in ipairs(data) do
+                                if line ~= "" then
+                                    table.insert(stderr, line)
+                                end
+                            end
+                        end
+                    end,
+                    on_exit = function(_, code)
+                        local output = table.concat(stdout, "\n")
+                        local error_output = table.concat(stderr, "\n")
+
+                        if output:match("Successfully uninstalled plugin") then
+                            vim.schedule(function()
+                                update_installed(chosen, false)
+                                vim.notify("✅ Uninstalled: " .. chosen, vim.log.levels.INFO)
+                            end)
+                        elseif code == 0 then
+                            vim.schedule(function()
+                                vim.notify("⚠️ Uninstalled, but unexpected output:\n" .. output, vim.log.levels.WARN)
+                            end)
+                        else
+                            vim.schedule(function()
+                                vim.notify("❌ Failed to uninstall '" .. chosen .. "':\n" .. error_output, vim.log.levels.ERROR)
+                            end)
+                        end
+                    end,
+                })
+            end)
+            return true
+        end,
+    }):find()
+end
+
 M.refresh_cache = function()
-  local success, err = os.remove(cache_path)
-  if success then
-    vim.notify("✅ Sigma plugin cache cleared successfully", vim.log.levels.INFO)
-  else
-    vim.notify("ℹ️ Failed to clear sigma plugin cache: ", err, vim.log.levels.WARN)
-  end
+    local success, err = os.remove(cache_path)
+    if success then
+        vim.notify("✅ Sigma plugin cache cleared successfully", vim.log.levels.INFO)
+    else
+        vim.notify("ℹ️ Failed to clear sigma plugin cache: ", err, vim.log.levels.WARN)
+    end
 end
 
 return M


### PR DESCRIPTION
Addition of `uninstall_sigma_target()` option for sigma plugin. This is facilitated by the cache having an extra boolean `installed` column.
Note that all installation of sigma plugins outside of sigma_picker.nvim will not be tracked by the cache.